### PR TITLE
Add support for Arduino Due's software erase hack

### DIFF
--- a/src/bossac.cpp
+++ b/src/bossac.cpp
@@ -64,7 +64,7 @@ public:
     bool help;
     bool forceUsb;
     string forceUsbArg;
-	bool arduinoErase;
+    bool arduinoErase;
 
     int readArg;
     string portArg;
@@ -90,7 +90,7 @@ BossaConfig::BossaConfig()
     info = false;
     help = false;
     forceUsb = false;
-	arduinoErase = false;
+    arduinoErase = false;
 
     readArg = 0;
     bootArg = 1;
@@ -191,12 +191,12 @@ static Option opts[] =
       'R', "reset", &config.reset,
       { ArgNone },
       "reset CPU (if supported)"
-	},
-	{
-	  'a', "arduino_erase", &config.arduinoErase,
-	  { ArgNone },
-	  "erase and reset via Arduino 1200 baud hack (cannot be used with port autodetection)"
-	}
+    },
+    {
+      'a', "arduino_erase", &config.arduinoErase,
+      { ArgNone },
+      "erase and reset via Arduino 1200 baud hack (cannot be used with port autodetection)"
+    }
 };
 
 bool
@@ -264,11 +264,11 @@ main(int argc, char* argv[])
         return help(argv[0]);
     }
 
-	if (config.arduinoErase && !config.port)
-	{
-		fprintf(stderr, "%s: port must be specified for Arduino erase hack\n", argv[0]);
-		return help(argv[0]);
-	}
+    if (config.arduinoErase && !config.port)
+    {
+        fprintf(stderr, "%s: port must be specified for Arduino erase hack\n", argv[0]);
+        return help(argv[0]);
+    }
 
     if (config.read || config.write || config.verify)
     {
@@ -326,18 +326,18 @@ main(int argc, char* argv[])
             }
         }
 
-		// Arduino 1200 baud erase hack (just open and close port at 1200 baud).
-		if (config.arduinoErase)
-		{
-			SerialPort::Ptr port;
-			if (config.forceUsb)
-				port = portFactory.create(config.portArg, isUsb);
-			else
-				port = portFactory.create(config.portArg);
+        // Arduino 1200 baud erase hack (just open and close port at 1200 baud).
+        if (config.arduinoErase)
+        {
+            SerialPort::Ptr port;
+            if (config.forceUsb)
+                port = portFactory.create(config.portArg, isUsb);
+            else
+                port = portFactory.create(config.portArg);
 
-			port->open(1200);
-			port->close();
-		}
+            port->open(1200);
+            port->close();
+        }
 
         if (config.port)
         {

--- a/src/bossac.cpp
+++ b/src/bossac.cpp
@@ -64,6 +64,7 @@ public:
     bool help;
     bool forceUsb;
     string forceUsbArg;
+	bool arduinoErase;
 
     int readArg;
     string portArg;
@@ -89,6 +90,7 @@ BossaConfig::BossaConfig()
     info = false;
     help = false;
     forceUsb = false;
+	arduinoErase = false;
 
     readArg = 0;
     bootArg = 1;
@@ -189,7 +191,12 @@ static Option opts[] =
       'R', "reset", &config.reset,
       { ArgNone },
       "reset CPU (if supported)"
-    }
+	},
+	{
+	  'a', "arduino_erase", &config.arduinoErase,
+	  { ArgNone },
+	  "erase and reset via Arduino 1200 baud hack (cannot be used with port autodetection)"
+	}
 };
 
 bool
@@ -257,6 +264,12 @@ main(int argc, char* argv[])
         return help(argv[0]);
     }
 
+	if (config.arduinoErase && !config.port)
+	{
+		fprintf(stderr, "%s: port must be specified for Arduino erase hack\n", argv[0]);
+		return help(argv[0]);
+	}
+
     if (config.read || config.write || config.verify)
     {
         if (args == argc)
@@ -312,6 +325,19 @@ main(int argc, char* argv[])
                 return 1;
             }
         }
+
+		// Arduino 1200 baud erase hack (just open and close port at 1200 baud).
+		if (config.arduinoErase)
+		{
+			SerialPort::Ptr port;
+			if (config.forceUsb)
+				port = portFactory.create(config.portArg, isUsb);
+			else
+				port = portFactory.create(config.portArg);
+
+			port->open(1200);
+			port->close();
+		}
 
         if (config.port)
         {


### PR DESCRIPTION
The Arduino Due's USB-to-Serial interface chip has special code that
will erase and reset the SAM3X8E if you open a 1200 baud connection and
immediately close it. This very simple change adds a command line option
to bossac to do that (the option is '-a'). If you use this option you
must specify the port.

I tested it on Windows and it works fine.
